### PR TITLE
CSS minification now totally handled with gulp

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,6 @@ gems:
   - jekyll-autoprefixer
 
 sass:
-  style: compressed
   sass_dir: _sass
 
 exclude: [Gemfile, Gemfile.lock, README.md, gulpfile.js, package.json, node_modules]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
-    purify = require('gulp-purifycss');
+    purify = require('gulp-purifycss'),
+    cleanCSS = require('gulp-clean-css');
 
 var paths = {
   css: './_site/css/',
@@ -8,14 +9,15 @@ var paths = {
 
 var mainCSS = paths.css + 'main.css';
 
-gulp.task('purify-css', function() {
+gulp.task('css', function() {
   return gulp.src(mainCSS)
     .pipe(purify([paths.html]))
+    .pipe(cleanCSS())
     .pipe(gulp.dest(paths.css));
 });
 
 gulp.task('watch', function() {
-  gulp.watch(mainCSS, ['purify-css']);
+  gulp.watch(mainCSS, ['css']);
 });
 
-gulp.task('default', ['watch', 'purify-css']);
+gulp.task('default', ['watch', 'css']);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "license": "MIT",
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-purifycss": "^0.2.0"
+    "gulp-clean-css": "^3.0.4",
+    "gulp-purifycss": "^0.2.0",
+    "purify-css": "^1.1.9"
   },
   "scripts": {
     "watch-css": "gulp"

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,12 @@ clean-css@^3.2.10:
     commander "2.8.x"
     source-map "0.4.x"
 
+clean-css@^4.0.9:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.0.10.tgz#6be448d6ba8c767654ebe11f158b97a887cb713f"
+  dependencies:
+    source-map "0.5.x"
+
 cliui@^3.0.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -406,6 +412,15 @@ graceful-fs@~1.2.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+gulp-clean-css@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/gulp-clean-css/-/gulp-clean-css-3.0.4.tgz#0c5ad8d045407c88f3c2b9f03570963967dcfd54"
+  dependencies:
+    clean-css "^4.0.9"
+    gulp-util "^3.0.8"
+    through2 "^2.0.3"
+    vinyl-sourcemaps-apply "^0.2.1"
+
 gulp-purifycss@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/gulp-purifycss/-/gulp-purifycss-0.2.0.tgz#182c4bade8ec9978a9f813663e6921afc1a350a3"
@@ -415,11 +430,7 @@ gulp-purifycss@^0.2.0:
     purify-css "^1.0.8"
     through2 "^2.0.0"
 
-gulp-rename@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.2.2.tgz#3ad4428763f05e2764dec1c67d868db275687817"
-
-gulp-util@^3.0.0, gulp-util@^3.0.5:
+gulp-util@^3.0.0, gulp-util@^3.0.5, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -904,7 +915,7 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-purify-css@^1.0.8:
+purify-css@^1.0.8, purify-css@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/purify-css/-/purify-css-1.1.9.tgz#46c9acd8940f3076c0c346c027e286f996168357"
   dependencies:
@@ -1041,6 +1052,10 @@ source-map@0.4.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.5.x, source-map@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
 source-map@^0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
@@ -1091,7 +1106,7 @@ through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
@@ -1159,6 +1174,12 @@ vinyl-fs@^0.3.0:
     strip-bom "^1.0.0"
     through2 "^0.6.1"
     vinyl "^0.4.0"
+
+vinyl-sourcemaps-apply@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
+  dependencies:
+    source-map "^0.5.1"
 
 vinyl@^0.4.0:
   version "0.4.6"


### PR DESCRIPTION
# Context

This was done cause purify has problems purifying minified files, so Jekyll CSS minification was removed. This was done by:

- Added gulp-clean-css dependency
- Added minification to CSS gulp task pipeline

This closes #19 

[Site available here](https://simian-ci.firebaseapp.com/)

## Links

* [gulp-clean-css](https://github.com/scniro/gulp-clean-css) used to minify css