### PR TITLE
fluid titles for description and cta sections

### DIFF
--- a/_includes/cta.html
+++ b/_includes/cta.html
@@ -3,8 +3,7 @@
 <section class="cta site-section" id="cta">
   <div class="container">
     <div class="row">
-
-      <div class="col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+      <div class="col-12">
         <h2 class="cta-title text-center">{{ section.title }}</h2>
       </div>
 
@@ -13,7 +12,6 @@
           {% include notify_form.html placeholder = "Email Address" %}
         </div>
       </div>
-
     </div>
   </div>
 </section>

--- a/_includes/description.html
+++ b/_includes/description.html
@@ -4,7 +4,7 @@
   <div class="container">
 
     <div class="row">
-      <div class="col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
+      <div class="col-12">
         <h2 class="description-title text-center">{{ section.title }}</h2>
       </div>
     </div>


### PR DESCRIPTION
# Context
This PR changes description and cta titles to use all the available space in the column (col-12)

## Media

![image](https://cloud.githubusercontent.com/assets/849872/25074238/4b5bb1c6-22bc-11e7-8de8-c249642b9048.png)

![image](https://cloud.githubusercontent.com/assets/849872/25074241/56230708-22bc-11e7-850d-188063e4a00b.png)
